### PR TITLE
Update module name to match the repository.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 # Changelog
 
 ## v0.9.0
-* [\#47](https://github.com/interchainio/tm-load-test/pull/47) - Makes sure
+* [\#47](https://github.com/informalsystems/tm-load-test/pull/47) - Makes sure
   that the KVStore client's `GenerateTx` method honours the preconfigured
   transaction size. **NB: This involves a breaking API change!** Please see
   [the client API documentation](./pkg/loadtest/README.md) for more details.
 
 ## v0.8.0
-* [\#42](https://github.com/interchainio/tm-load-test/pull/42) - Add Prometheus
+* [\#42](https://github.com/informalsystems/tm-load-test/pull/42) - Add Prometheus
   gauge for when load test is underway. This indicator exposes a customizable
   load test ID.
 
@@ -15,64 +15,64 @@
 * Re-released due to v0.7.0 being incorrectly tagged
 
 ## v0.7.0
-* [\#39](https://github.com/interchainio/tm-load-test/pull/40) - Add basic
+* [\#39](https://github.com/informalsystems/tm-load-test/pull/40) - Add basic
   aggregate statistics output to CSV file.
 * Added integration test for standalone execution happy path.
 
 ## v0.6.2
-* [\#37](https://github.com/interchainio/tm-load-test/pull/37) - Fix average
+* [\#37](https://github.com/informalsystems/tm-load-test/pull/37) - Fix average
   transaction throughput rate in reporting/metrics.
 
 ## v0.6.1
-* [\#35](https://github.com/interchainio/tm-load-test/pull/35) - Minor fix for
+* [\#35](https://github.com/informalsystems/tm-load-test/pull/35) - Minor fix for
   broken shutdown-wait functionality.
 
 ## v0.6.0
-* [\#33](https://github.com/interchainio/tm-load-test/pull/33) - Add ability
+* [\#33](https://github.com/informalsystems/tm-load-test/pull/33) - Add ability
   to wait for a minimum level of connectivity between peers before starting the
   load testing (through a `--min-peer-connectivity` command line switch).
 
 ## v0.5.1
-* [\#31](https://github.com/interchainio/tm-load-test/pull/31) - Expand on
+* [\#31](https://github.com/informalsystems/tm-load-test/pull/31) - Expand on
   endpoint selection strategy to now allow for 3 different strategies:
   `supplied`, `discovered` and `any`. Allows for specifying of a seed node
   endpoint that one doesn't want to use during the actual load testing.
 
 ## v0.5.0
-* [\#23](https://github.com/interchainio/tm-load-test/pull/23) - Add
+* [\#23](https://github.com/informalsystems/tm-load-test/pull/23) - Add
   feature to wait for Tendermint network stabilization before starting load
   testing (in standalone and master/slave modes).
-* [\#28](https://github.com/interchainio/tm-load-test/pull/28) - Expose the
+* [\#28](https://github.com/informalsystems/tm-load-test/pull/28) - Expose the
   tx throughput rates via Prometheus.
 
 ## v0.4.2
 * Adds version sub-command to the CLI
 
 ## v0.4.1
-* [\#21](https://github.com/interchainio/tm-load-test/pull/21) - Add support
+* [\#21](https://github.com/informalsystems/tm-load-test/pull/21) - Add support
   for exposing Prometheus-compatible metrics from the MASTER web server via
   the `/metrics` endpoint. This now provides simple high-level information
   about the overall load test, like number of transactions sent (overall, and
   per-slave), and the state of the master and each attached slave.
 
 ## v0.4.0
-* [\#20](https://github.com/interchainio/tm-load-test/pull/20) - Significant
+* [\#20](https://github.com/informalsystems/tm-load-test/pull/20) - Significant
   refactor of the underlying codebase to radically simplify the code and make
   its usage easier and more closely aligned with `tm-bench`.
 
 ## v0.3.0
-* [\#15](https://github.com/interchainio/tm-load-test/pull/14) - Add example
+* [\#15](https://github.com/informalsystems/tm-load-test/pull/14) - Add example
   configuration for outage simulation while load testing.
-* [\#14](https://github.com/interchainio/tm-load-test/pull/14) - Add support for
+* [\#14](https://github.com/informalsystems/tm-load-test/pull/14) - Add support for
   the outage simulator from the master node during load testing.
-* [\#13](https://github.com/interchainio/tm-load-test/pull/13) - Add basic HTTP
+* [\#13](https://github.com/informalsystems/tm-load-test/pull/13) - Add basic HTTP
   authentication to `tm-outage-sim-server` utility.
-* [\#12](https://github.com/interchainio/tm-load-test/pull/12) - Add standalone
+* [\#12](https://github.com/informalsystems/tm-load-test/pull/12) - Add standalone
   mode to be able to run load testing tool locally in a simple way.
-* [\#11](https://github.com/interchainio/tm-load-test/pull/11) - Allow for basic
+* [\#11](https://github.com/informalsystems/tm-load-test/pull/11) - Allow for basic
   HTTP authentication between the master and slave nodes for additional
   security.
-* [\#10](https://github.com/interchainio/tm-load-test/pull/10) - Allow clients
+* [\#10](https://github.com/informalsystems/tm-load-test/pull/10) - Allow clients
   to continuously send transactions until the maximum time limit is reached
   without having a limit imposed on the number of transactions.
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: build-tm-load-test build-tm-outage-sim-server
 
 build-tm-load-test:
 	@go build $(BUILD_FLAGS) \
-		-ldflags "-X github.com/interchainio/tm-load-test/pkg/loadtest.cliVersionCommitID=`git rev-parse --short HEAD`" \
+		-ldflags "-X github.com/informalsystems/tm-load-test/pkg/loadtest.cliVersionCommitID=`git rev-parse --short HEAD`" \
 		-o $(BUILD_DIR)/tm-load-test ./cmd/tm-load-test/main.go
 
 build-tm-outage-sim-server:

--- a/cmd/tm-load-test/main.go
+++ b/cmd/tm-load-test/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/interchainio/tm-load-test/pkg/loadtest"
+	"github.com/informalsystems/tm-load-test/pkg/loadtest"
 )
 
 const appLongDesc = `Load testing application for Tendermint with optional master/slave mode.

--- a/cmd/tm-outage-sim-server/main.go
+++ b/cmd/tm-outage-sim-server/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/interchainio/tm-load-test/internal/outagesim"
+	"github.com/informalsystems/tm-load-test/internal/outagesim"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/interchainio/tm-load-test
+module github.com/informalsystems/tm-load-test
 
 go 1.15
 

--- a/pkg/loadtest/README.md
+++ b/pkg/loadtest/README.md
@@ -31,7 +31,7 @@ in `./pkg/myabciapp/client.go`
 ```go
 package myabciapp
 
-import "github.com/interchainio/tm-load-test/pkg/loadtest"
+import "github.com/informalsystems/tm-load-test/pkg/loadtest"
 
 // MyABCIAppClientFactory creates instances of MyABCIAppClient
 type MyABCIAppClientFactory struct {}
@@ -74,7 +74,7 @@ Create your own CLI in `./cmd/my-load-tester/main.go`:
 package main
 
 import (
-    "github.com/interchainio/tm-load-test/pkg/loadtest"
+    "github.com/informalsystems/tm-load-test/pkg/loadtest"
     "github.com/you/my-load-tester/pkg/myabciapp"
 )
 

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/pkg/loadtest/client_kvstore_test.go
+++ b/pkg/loadtest/client_kvstore_test.go
@@ -3,7 +3,7 @@ package loadtest_test
 import (
 	"testing"
 
-	"github.com/interchainio/tm-load-test/pkg/loadtest"
+	"github.com/informalsystems/tm-load-test/pkg/loadtest"
 )
 
 func TestKVStoreClientFactoryConfigValidation(t *testing.T) {
@@ -91,8 +91,8 @@ func BenchmarkKVStoreClient_GenerateTx_100kB(b *testing.B) {
 }
 
 func TestKVStoreClient(t *testing.T) {
-	testCases := []struct{
-		config loadtest.Config
+	testCases := []struct {
+		config      loadtest.Config
 		clientCount int
 	}{
 		{loadtest.Config{Size: 32, Count: 1000}, 5},

--- a/pkg/loadtest/integration_test.go
+++ b/pkg/loadtest/integration_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/interchainio/tm-load-test/pkg/loadtest"
+	"github.com/informalsystems/tm-load-test/pkg/loadtest"
 	"github.com/tendermint/tendermint/abci/example/kvstore"
 	rpctest "github.com/tendermint/tendermint/rpc/test"
 )

--- a/pkg/loadtest/loadtest.go
+++ b/pkg/loadtest/loadtest.go
@@ -3,7 +3,7 @@ package loadtest
 import (
 	"time"
 
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 )
 
 // ExecuteStandalone will run a standalone (non-master/slave) load test.

--- a/pkg/loadtest/master.go
+++ b/pkg/loadtest/master.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"

--- a/pkg/loadtest/remote_slave.go
+++ b/pkg/loadtest/remote_slave.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )

--- a/pkg/loadtest/slave.go
+++ b/pkg/loadtest/slave.go
@@ -8,7 +8,7 @@ import (
 	"unicode"
 
 	"github.com/gorilla/websocket"
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/pkg/loadtest/tm_network_info.go
+++ b/pkg/loadtest/tm_network_info.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	"github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
 )

--- a/pkg/loadtest/transactor.go
+++ b/pkg/loadtest/transactor.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 	rpctypes "github.com/tendermint/tendermint/rpc/jsonrpc/types"
 )
 

--- a/pkg/loadtest/websockets.go
+++ b/pkg/loadtest/websockets.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/interchainio/tm-load-test/internal/logging"
+	"github.com/informalsystems/tm-load-test/internal/logging"
 )
 
 const (


### PR DESCRIPTION
Since this module was moved to a new repository, the go tool complains on
import that its declared name doesn't match its requirement spec:

```
 module declares its path as: github.com/interchainio/tm-load-test
        but was required as: github.com/informalsystems/tm-load-test
```

This updates the module declaration and the internal import paths, along with
the build string injection rule in the Makefile.

Since the repository was forwarded, and all the existing issues still work at
the new address, I also updated the changelog for consistency.

(I ran into this while investigating tendermint/tendermint/issues/7032)