### PR TITLE
Fix links to GitHub to the specific version of Tendermint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `tm-load-test` is a distributed load testing tool (and framework) for load
 testing [Tendermint](https://tendermint.com/) networks and aims to effectively
-be the successor to [`tm-bench`](https://github.com/tendermint/tendermint/tree/master/tools/tm-bench).
+be the successor to [`tm-bench`](https://github.com/tendermint/tendermint/tree/v0.32.x/tools/tm-bench).
 
 Naturally, any  transactions sent to a Tendermint network are specific to the
 ABCI application running on that network. As such, the `tm-load-test` tool comes

--- a/pkg/loadtest/transactor.go
+++ b/pkg/loadtest/transactor.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	connSendTimeout = 10 * time.Second
-	// see https://github.com/tendermint/tendermint/blob/master/rpc/lib/server/handlers.go
+	// see https://github.com/tendermint/tendermint/blob/v0.32.x/rpc/lib/server/handlers.go
 	connPingPeriod = (30 * 9 / 10) * time.Second
 
 	jsonRPCID = rpctypes.JSONRPCStringID("tm-load-test")


### PR DESCRIPTION
Fixes two links to Tendermint v0.32 (the original version of Tendermint used to create this tool). The links still provide useful context, even though that version's no longer officially supported.