### PR TITLE
Integration test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,10 +186,29 @@ avg_tx_rate,899.818398,transactions per second
 ```
 
 ## Development
+
 To run the linter and the tests:
 
 ```bash
 make lint
 make test
 ```
+
+### Integration Testing
+
+Integration testing requires Docker to be installed locally.
+
+```bash
+make integration-test
+```
+
+This integration test:
+
+1. Sets up a 4-validator, fully connected Tendermint Core-based network on a
+   192.168.0.0/16 subnet (the same kind of testnet as the Tendermint Core
+   localnet).
+2. Executes integration tests against the network in series (it's important that
+   integration tests be executed in series so as to not overlap with one
+   another).
+3. Tears down the 4-validator network, reporting code coverage.
 

--- a/pkg/loadtest/integration_test.go
+++ b/pkg/loadtest/integration_test.go
@@ -219,7 +219,7 @@ func testConfig(tempDir string) loadtest.Config {
 		NoTrapInterrupts:     true,
 		PeerConnectTimeout:   30,
 		MinConnectivity:      4,
-		ExpectPeers:          1,
+		ExpectPeers:          4,
 	}
 }
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+#
+# This script is intended to be executed from the root of the tm-load-test
+# repository.
 
 make localnet-stop || exit 1
 rm -rf build


### PR DESCRIPTION
Minor improvements after merging #168.

It appears as though the integration test was running non-deterministically. One hypothesis I have about why is that it was attempting to execute the load test prior to the network being fully connected, resulting in no transactions being sent. This increases the minimum connectivity requirements before the load tests begin in the integration tests.