### PR TITLE
Bump minimum Go version to 1.19

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,6 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.4.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.50.1
+          version: v1.51
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3.2.0
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.18"
+          go-version: "1.19"
       - run: make integration-test
       - uses: codecov/codecov-action@v3.1.1
         with:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ your own clients](./pkg/loadtest/README.md) for your own apps.
 
 ## Requirements
 
-`tm-load-test` is currently tested using Go v1.18.
+`tm-load-test` is currently tested using Go v1.19.
 
 ## Building
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/informalsystems/tm-load-test
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gorilla/websocket v1.5.0


### PR DESCRIPTION
Go 1.18 is EOL and no longer supported.