### PR TITLE
ci: Update govulncheck and linter

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20.3"
+          go-version: "1.20"
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: actions/checkout@v3.2.0
       - uses: golangci/golangci-lint-action@v3.6.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51
+          version: latest
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ bench:
 .PHONY: bench
 
 lint:
-	golangci-lint run ./...
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run
 .PHONY: lint
 
 clean:


### PR DESCRIPTION
Updates govulncheck to use the latest patch release of Go, and the latest version of golangci-lint.

A bunch of the other Dependabot updates are failing because this uses a hard-coded version of Go in the govulncheck workflow in CI.