### PR TITLE
ci: Use latest version of Go

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20"
+          check-latest: true
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,8 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '>=1.20'
+          check-latest: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v3.2.0
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: ">=1.20"
+          check-latest: true
       - run: make integration-test
       - uses: codecov/codecov-action@v3.1.4
         with:


### PR DESCRIPTION
Update CI to always attempt to use the latest versions of Go.